### PR TITLE
fix objective of tutorial lesson -p1  -l4

### DIFF
--- a/tutorial.toml
+++ b/tutorial.toml
@@ -62,7 +62,7 @@ objectives = """
     * Include "Displays a greeting."
   * Add help text to the `--greeting`:
     * "The greeting to display"
-  * Add help text to and `--question`:
+  * Add help text to the `--question`:
     * "Make the greeting a question"
 """
 doc-urls = "https://click.palletsprojects.com/en/7.x/documentation/"

--- a/tutorial.toml
+++ b/tutorial.toml
@@ -61,9 +61,9 @@ objectives = """
   * Add general command usage help
     * Include "Displays a greeting."
   * Add help text to the `--greeting`:
-    * "Make the greeting a question"
-  * Add help text to and `--question`:
     * "The greeting to display"
+  * Add help text to and `--question`:
+    * "Make the greeting a question"
 """
 doc-urls = "https://click.palletsprojects.com/en/7.x/documentation/"
 


### PR DESCRIPTION
The objective for documenting --greeting and --question is reversed in the text displayed by `tutorial lesson -p1 -l4`.
The test (lessons/part_01/tests/04_help.py) doesn't care about this so it's not super important but this confused me and it might confuse others.